### PR TITLE
Make QueuingDiscipline available in prelude

### DIFF
--- a/src/apex/types.rs
+++ b/src/apex/types.rs
@@ -136,7 +136,7 @@ pub mod abstraction {
 
     // Reexport important basic-types for downstream-user
     pub use super::basic::{
-        ApexByte, ApexUnsigned, MessageSize, QueuingDiscipline, MAX_NAME_LENGTH,
+        ApexByte, ApexUnsigned, MessageRange, MessageSize, QueuingDiscipline, MAX_NAME_LENGTH,
     };
     use crate::bindings::*;
 

--- a/src/apex/types.rs
+++ b/src/apex/types.rs
@@ -135,7 +135,9 @@ pub mod abstraction {
     use core::time::Duration;
 
     // Reexport important basic-types for downstream-user
-    pub use super::basic::{ApexByte, ApexUnsigned, MessageSize, MAX_NAME_LENGTH};
+    pub use super::basic::{
+        ApexByte, ApexUnsigned, MessageSize, QueuingDiscipline, MAX_NAME_LENGTH,
+    };
     use crate::bindings::*;
 
     /// Error Type used by abstracted functions.  


### PR DESCRIPTION
`QueuingDiscipline` is needed when creating queuing port senders and receivers.